### PR TITLE
Fixed git clone command

### DIFF
--- a/docs/Getting-OTP.md
+++ b/docs/Getting-OTP.md
@@ -28,7 +28,7 @@ Once you have these packages installed, create and/or switch to the directory wh
 ```shell
 mkdir git
 cd git
-git clone git@github.com:opentripplanner/OpenTripPlanner.git
+git clone https://github.com/opentripplanner/OpenTripPlanner.git
 ```
 
 Then change to the newly cloned OpenTripPlanner repository directory and start a build:


### PR DESCRIPTION
Ran into a problem with old command

```
git clone https://github.com/opentripplanner/OpenTripPlanner.git
```

works
